### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ var beautify = require('gulp-beautify');
 
 gulp.task('beautify', function() {
   gulp.src('./src/*.js')
-    .pipe(beautify({indentSize: 2}))
+    .pipe(beautify({indent_size: 2}))
     .pipe(gulp.dest('./public/'))
 });
 ```


### PR DESCRIPTION
indentSize doesn't work for me, but indent_size do work! As the reference in [js-beautify](https://github.com/beautify-web/js-beautify) specifies, it should be "indent_size".